### PR TITLE
Improve join gossip dissemination

### DIFF
--- a/gossip.go
+++ b/gossip.go
@@ -155,9 +155,9 @@ func (q *gossipEventQueue) orderedView() []*gossipEvent {
 	return gossipQueue
 }
 
-// calcTransmitLimit will calculate transmit total using Log(N + 1) with N
+// calcTransmitLimit will calculate transmit limit using Log(N) + 1 with N
 // being the number of known nodes.
 func (q *gossipEventQueue) calcTransmitLimit() int {
-	limit := math.Ceil(math.Log10(float64(q.numNodes() + 1)))
+	limit := math.Ceil(math.Log10(float64(q.numNodes())) + 1)
 	return int(limit)
 }

--- a/transport.go
+++ b/transport.go
@@ -96,8 +96,8 @@ type NetTransport struct {
 func NewNetTransport(addr string, port uint16) (*NetTransport, error) {
 	ok := true
 	t := &NetTransport{
-		packetCh: make(chan *Packet),
-		streamCh: make(chan net.Conn),
+		packetCh: make(chan *Packet, 5),
+		streamCh: make(chan net.Conn, 5),
 		shutdown: make(chan struct{}),
 	}
 	defer func() {


### PR DESCRIPTION
### Problem

As the cluster grew, nodes that recently joined would not always be disseminated across the entire cluster. Some nodes never hear about the new node.

### What was done

Join gossip events were not being added to the current node's gossip list as expected. This was fixed in `Member#addNewNode` which should now return `succeed = false` only when the node is already added in the ping list  (and node map).

Changed the transmit limit calculation for gossip events from Log(N + 1) to Log(N) + 1